### PR TITLE
Update README for installation through Carthage

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,7 +722,7 @@ $ brew install carthage
 To integrate Cely into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "Cely/Cely" ~> 2.0.0
+github "chaione/Cely" ~> 2.0.0
 ```
 
 ### Manually


### PR DESCRIPTION
To clone the project through 'carthage update' command, repo Cely/Cely has been replaced by chaione/Cely.